### PR TITLE
mqtt-frigate connection fix

### DIFF
--- a/frigate/docker-compose.yml.j2
+++ b/frigate/docker-compose.yml.j2
@@ -4,6 +4,8 @@ services:
     container_name: frigate
     # privileged: true
     restart: unless-stopped
+    networks:
+      - frigate
     image: {{ frigate_container_image }}
     shm_size: "256mb"
     devices:


### PR DESCRIPTION
mqtt was not part of the same network, that's why frigate and mqtt couldn't see each other, fixes #10