### PR TITLE
cameras.basement.rtmp: Extra inputs are not permitted

### DIFF
--- a/example.config.yml
+++ b/example.config.yml
@@ -16,8 +16,6 @@ frigate_cameras:
         - path: "rtsp://camera_username:{FRIGATE_RTSP_PASSWORD}@ip_address_here:554/H264/ch1/main/av_stream"
           roles:
             - record
-    rtmp:
-      enabled: False
     detect:
       width: 640
       height: 360


### PR DESCRIPTION
When 
```
```
present, the log gets filled with
```
#2024-09-29 13:24:18.514188669  *************************************************************
#2024-09-29 13:24:18.514191021  ***    Config Validation Errors                           ***
#2024-09-29 13:24:18.514193372  *************************************************************
#2024-09-29 13:24:18.514302054  cameras.basement.rtmp: Extra inputs are not permitted
#2024-09-29 13:24:18.514306573  *************************************************************
#2024-09-29 13:24:18.514340738  ***    End Config Validation Errors                       ***
#2024-09-29 13:24:18.514344016  *************************************************************
```
