### PR TITLE
retaining only "motion" better default

### DIFF
--- a/example.config.yml
+++ b/example.config.yml
@@ -37,7 +37,7 @@ frigate_hwaccel_args: ""  # "preset-rpi-64-h264" for Pi 4
 frigate_storage_path: /mnt/frigate
 frigate_record_enabled: "True"
 frigate_record_retain_days: 7
-frigate_record_retain_mode: "all"
+frigate_record_retain_mode: "motion"  #"all" - full video, "motion" - only motion events, "active_objects" - only detected predefined objects
 frigate_container_image: ghcr.io/blakeblackshear/frigate:stable
 frigate_configure_mqtt_broker: true
 frigate_mosquitto_password: changeme

--- a/example.config.yml
+++ b/example.config.yml
@@ -37,7 +37,7 @@ frigate_hwaccel_args: ""  # "preset-rpi-64-h264" for Pi 4
 frigate_storage_path: /mnt/frigate
 frigate_record_enabled: "True"
 frigate_record_retain_days: 7
-frigate_record_retain_mode: "motion"  #"all" - full video, "motion" - only motion events, "active_objects" - only detected predefined objects
+frigate_record_retain_mode: "all"  #"all" - full video, "motion" - only motion events, "active_objects" - only detected predefined objects
 frigate_container_image: ghcr.io/blakeblackshear/frigate:stable
 frigate_configure_mqtt_broker: true
 frigate_mosquitto_password: changeme


### PR DESCRIPTION
retaining full recordings fills in space far faster than only "motion" events.